### PR TITLE
Refactor/env config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
-# Set the home directory for the node (default is your $HOME)
+# Set the home directory for the node
+# Default is your $HOME/hl, e.g. /home/ubuntu/hl
 NODE_HOME=
 
 # Set the binary location (default is $HOME/hl-visor)
@@ -10,6 +11,6 @@ IS_VALIDATOR=
 # Validator address
 VALIDATOR_ADDRESS=
 
-# Grafana credentials (will require you to update passphrase upon first login)
+# Grafana credentials (Will require you to update passphrase upon first login)
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=admin

--- a/docker/templates/docker-compose.yaml.tmpl
+++ b/docker/templates/docker-compose.yaml.tmpl
@@ -1,9 +1,8 @@
-version: '3.8'
 services:
   hl_exporter:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: docker/Dockerfile
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}

--- a/docker/templates/docker-compose.yaml.tmpl
+++ b/docker/templates/docker-compose.yaml.tmpl
@@ -11,9 +11,11 @@ services:
     environment:
       - HOSTNAME=hl_exporter
       - NODE_HOME=/node_home/
+      - BINARY_HOME=/binary_home/
     volumes:
       - ./:/app
       - ${NODE_HOME}:/node_home/
+      - ${BINARY_HOME}:/binary_home/
     restart: unless-stopped
 
   prometheus:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -20,8 +20,8 @@ echo "Using USER_ID=$USER_ID and GROUP_ID=$GROUP_ID"
 
 # Use $HOME if NODE_HOME is unset or empty
 if [ -z "$NODE_HOME" ]; then
-    export NODE_HOME="$HOME"
-    echo "NODE_HOME is not set in .env file. Using HOME directory: $NODE_HOME"
+    export NODE_HOME="${HOME}/hl"
+    echo "NODE_HOME is not set in .env file. Using HOME directory: ${NODE_HOME}/hl"
 else
     echo "Using NODE_HOME=$NODE_HOME"
 fi

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -26,9 +26,22 @@ else
     echo "Using NODE_HOME=$NODE_HOME"
 fi
 
+if [ -z "$GRAFANA_ADMIN_USER" ]; then
+    export GRAFANA_ADMIN_USER="admin"
+    echo "GRAFANA_ADMIN_USER is not set in .env file. Using user: admin"
+else
+    echo "Using GRAFANA_ADMIN_USER=$GRAFANA_ADMIN_USER"
+fi
+if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
+    export GRAFANA_ADMIN_PASSWORD="admin"
+    echo "GRAFANA_ADMIN_PASSWORD is not set in .env file. Using user: admin"
+else
+    echo "Using GRAFANA_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD"
+fi
+
 # Generate files from templates
 envsubst '${USER_ID},${GROUP_ID}' < docker/templates/Dockerfile.tmpl > docker/Dockerfile
-envsubst '${USER_ID},${GROUP_ID},${NODE_HOME}' < docker/templates/docker-compose.yaml.tmpl > docker/docker-compose.yaml
+envsubst '${USER_ID},${GROUP_ID},${NODE_HOME},${GRAFANA_ADMIN_USER},${GRAFANA_ADMIN_PASSWORD}' < docker/templates/docker-compose.yaml.tmpl > docker/docker-compose.yaml
 envsubst < prometheus/prometheus.yml.tmpl > prometheus/prometheus.yml
 
 echo "Dockerfile, docker-compose.yaml and prometheus.yml have been generated successfully."

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -18,13 +18,22 @@ export GROUP_ID=$(id -g)
 
 echo "Using USER_ID=$USER_ID and GROUP_ID=$GROUP_ID"
 
-# Use $HOME if NODE_HOME is unset or empty
 if [ -z "$NODE_HOME" ]; then
     export NODE_HOME="${HOME}/hl"
     echo "NODE_HOME is not set in .env file. Using HOME directory: ${NODE_HOME}/hl"
 else
     echo "Using NODE_HOME=$NODE_HOME"
 fi
+
+if [ -z "$NODE_BINARY" ]; then
+    export NODE_BINARY="${HOME}/hl-visor"
+    echo "NODE_BINARY is not set in .env file. Using default path: ${HOME}/hl-visor"
+else
+    echo "Using NODE_BINARY=$NODE_BINARY"
+fi
+
+export BINARY_HOME=$(dirname "$NODE_BINARY")
+
 
 if [ -z "$GRAFANA_ADMIN_USER" ]; then
     export GRAFANA_ADMIN_USER="admin"


### PR DESCRIPTION
Implements modular user environment configuration by extracting binary locations and mount directories into dedicated paths.

- Introduces `BINARY_HOME` as a separate mount from `NODE_HOME`, with only purpose of running `hl-visor` to extract versino info, which improves isolation and handling non-default setups
- Updates Docker Compose to handle paths explicitly for better clarity