### PR TITLE
add support for Docker node setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
-# Set the home directory for the node
+# Set to 'true' if the Hyperliquid node is running in Docker, 'false' otherwise
+USE_DOCKER=false
+
+# Set the home directory for the node (used if USE_DOCKER=false)
 # Default is your $HOME/hl, e.g. /home/ubuntu/hl
 NODE_HOME=
 

--- a/docker/templates/Dockerfile.tmpl
+++ b/docker/templates/Dockerfile.tmpl
@@ -26,7 +26,7 @@ USER ubuntu
 WORKDIR /app
 
 # Copy .env file from local directory into the container
-COPY --chown=ubuntu:ubuntu ../.env /app/.env
+COPY --chown=ubuntu:ubuntu ./.env /app/.env
 
 # Command to run the binary
 CMD ["/usr/local/bin/hl_exporter", "start"]

--- a/docker/templates/Dockerfile.tmpl
+++ b/docker/templates/Dockerfile.tmpl
@@ -26,7 +26,7 @@ USER ubuntu
 WORKDIR /app
 
 # Copy .env file from local directory into the container
-COPY --chown=ubuntu:ubuntu .env /app/.env
+COPY --chown=ubuntu:ubuntu ../.env /app/.env
 
 # Command to run the binary
 CMD ["/usr/local/bin/hl_exporter", "start"]

--- a/docker/templates/Dockerfile.tmpl
+++ b/docker/templates/Dockerfile.tmpl
@@ -26,7 +26,7 @@ USER ubuntu
 WORKDIR /app
 
 # Copy .env file from local directory into the container
-COPY --chown=ubuntu:ubuntu ./.env /app/.env
+COPY --chown=ubuntu:ubuntu .env /app/.env
 
 # Command to run the binary
 CMD ["/usr/local/bin/hl_exporter", "start"]

--- a/docker/templates/docker-compose.yaml.tmpl
+++ b/docker/templates/docker-compose.yaml.tmpl
@@ -9,12 +9,11 @@ services:
     container_name: hl_exporter
     environment:
       - HOSTNAME=hl_exporter
-      - NODE_HOME=/node_home/
-      - BINARY_HOME=/binary_home/
+      - NODE_HOME=/home/hluser/hl
+      - BINARY_HOME=/home/hluser
     volumes:
       - ./:/app
-      - ${NODE_HOME}:/node_home/
-      - ${BINARY_HOME}:/binary_home/
+${VOLUME_MOUNTS}
     restart: unless-stopped
 
   prometheus:
@@ -57,3 +56,4 @@ services:
 volumes:
   prometheus_data:
   grafana_data:
+${EXTRA_VOLUMES}

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -18,22 +18,34 @@ export GROUP_ID=$(id -g)
 
 echo "Using USER_ID=$USER_ID and GROUP_ID=$GROUP_ID"
 
-if [ -z "$NODE_HOME" ]; then
-    export NODE_HOME="${HOME}/hl"
-    echo "NODE_HOME is not set in .env file. Using HOME directory: ${NODE_HOME}/hl"
+if [ "$USE_DOCKER" = "true" ]; then
+    export NODE_HOME="/home/hluser/hl"
+    export BINARY_HOME="/home/hluser"
+    export VOLUME_MOUNTS="      - hyperliquid_hl-data:/home/hluser/hl/data:ro"
+    export EXTRA_VOLUMES="  hyperliquid_hl-data:
+    external: true"
+    echo "Using Docker setup for Hyperliquid node"
 else
-    echo "Using NODE_HOME=$NODE_HOME"
+    if [ -z "$NODE_HOME" ]; then
+        export NODE_HOME="${HOME}/hl"
+        echo "NODE_HOME is not set in .env file. Using default path: ${NODE_HOME}"
+    else
+        echo "Using NODE_HOME=$NODE_HOME"
+    fi
+
+    if [ -z "$NODE_BINARY" ]; then
+        export NODE_BINARY="${HOME}/hl-visor"
+        echo "NODE_BINARY is not set in .env file. Using default path: ${NODE_BINARY}"
+    else
+        echo "Using NODE_BINARY=$NODE_BINARY"
+    fi
+
+    export BINARY_HOME=$(dirname "$NODE_BINARY")
+    export VOLUME_MOUNTS="      - ${NODE_HOME}:/home/hluser/hl:ro
+      - ${BINARY_HOME}:/home/hluser:ro"
+    export EXTRA_VOLUMES=""
+    echo "Using local setup for Hyperliquid node"
 fi
-
-if [ -z "$NODE_BINARY" ]; then
-    export NODE_BINARY="${HOME}/hl-node"
-    echo "NODE_BINARY is not set in .env file. Using default path: ${HOME}/hl-node"
-else
-    echo "Using NODE_BINARY=$NODE_BINARY"
-fi
-
-export BINARY_HOME=$(dirname "$NODE_BINARY")
-
 
 if [ -z "$GRAFANA_ADMIN_USER" ]; then
     export GRAFANA_ADMIN_USER="admin"
@@ -41,16 +53,17 @@ if [ -z "$GRAFANA_ADMIN_USER" ]; then
 else
     echo "Using GRAFANA_ADMIN_USER=$GRAFANA_ADMIN_USER"
 fi
+
 if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
     export GRAFANA_ADMIN_PASSWORD="admin"
-    echo "GRAFANA_ADMIN_PASSWORD is not set in .env file. Using user: admin"
+    echo "GRAFANA_ADMIN_PASSWORD is not set in .env file. Using password: admin"
 else
     echo "Using GRAFANA_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD"
 fi
 
 # Generate files from templates
 envsubst '${USER_ID},${GROUP_ID}' < docker/templates/Dockerfile.tmpl > docker/Dockerfile
-envsubst '${USER_ID},${GROUP_ID},${NODE_HOME},${BINARY_HOME},${NODE_BINARY},${GRAFANA_ADMIN_USER},${GRAFANA_ADMIN_PASSWORD}' < docker/templates/docker-compose.yaml.tmpl > docker/docker-compose.yaml
+envsubst '${USER_ID},${GROUP_ID},${NODE_HOME},${BINARY_HOME},${GRAFANA_ADMIN_USER},${GRAFANA_ADMIN_PASSWORD},${VOLUME_MOUNTS},${EXTRA_VOLUMES}' < docker/templates/docker-compose.yaml.tmpl > docker/docker-compose.yaml
 envsubst < prometheus/prometheus.yml.tmpl > prometheus/prometheus.yml
 
 echo "Dockerfile, docker-compose.yaml and prometheus.yml have been generated successfully."


### PR DESCRIPTION
# Add support for Docker and non-Docker Hyperliquid node setups

This PR updates the monitoring stack config to support both Docker and local setups of an HL node.

## Changes

1. Updated `generate_config.sh`:
   - Added conditional logic based on the `USE_DOCKER` environment variable.
   - Added different volume mount for Docker and non-Docker setups.
   - Updated `envsubst` 

2. Modified `.env.sample` file:
   - Added `USE_DOCKER` flag to differentiate between Docker and non-Docker setups.

3. Modified `docker-compose.yaml.tmpl`:
   - Implemented variable substitution for volume mounts and extra volumes.
   - Ensured compatibility with both Docker and non-Docker setups.

## How to use

1. Set `USE_DOCKER=true` in `.env` file if running Hyperliquid node in Docker, otherwise set to `false`.
2. For non-Docker setups, optionally set `NODE_HOME` and `NODE_BINARY` in `.env` file.
3. Run `./generate_config.sh` to generate the appropriate configuration files.


PS:
modified `Dockerfile.tmpl` to correctly copy the .env file if the user follows the README... but maybe should just change the README instead.