### PR TITLE
refactor: use bind mount for .env

### DIFF
--- a/docker/templates/Dockerfile.tmpl
+++ b/docker/templates/Dockerfile.tmpl
@@ -25,8 +25,8 @@ USER ubuntu
 # Set working directory
 WORKDIR /app
 
-# Copy .env file from local directory into the container
-COPY --chown=ubuntu:ubuntu .env /app/.env
+# Rely on bind mount in docker-compose.yml instead
+# COPY --chown=ubuntu:ubuntu .env /app/.env
 
 # Command to run the binary
 CMD ["/usr/local/bin/hl_exporter", "start"]

--- a/docker/templates/docker-compose.yaml.tmpl
+++ b/docker/templates/docker-compose.yaml.tmpl
@@ -12,7 +12,7 @@ services:
       - NODE_HOME=/home/hluser/hl
       - BINARY_HOME=/home/hluser
     volumes:
-      - ./:/app
+      - ../.env:/app/.env
 ${VOLUME_MOUNTS}
     restart: unless-stopped
 


### PR DESCRIPTION
- use a bind mount to access `.env` for `hl_exporter`
- allows to make config changes without rebuilding image